### PR TITLE
be able to use a parse a string containing sql queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rawsql"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Manuel Alonso <manuel.alonso@protonmail.com>"]
 license = "MIT"
 description = "A rust library for reusing SQL"
@@ -16,4 +16,4 @@ path = "src/lib.rs"
 doctest = false
 
 [dev-dependencies]
-postgres = "0.10"
+postgres = "0.19.2"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can integrate rawsql into your project through the [releases on crates.io](h
 ```toml
 # Cargo.toml
 [dependencies]
-rawsql = "0.1.0"
+rawsql = "0.1.1"
 ```
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ fn main() {
     let queries = Loader::get_queries_from("examples/postgre.sql").unwrap().queries;
 
     //Insert query
-    let qìnsert = queries.get("insert-person").unwrap();
+    let qinsert = queries.get("insert-person").unwrap();
 
     println!("{}", qinsert);
 

--- a/examples/posgtre.rs
+++ b/examples/posgtre.rs
@@ -1,8 +1,8 @@
-extern crate rawsql;
 extern crate postgres;
+extern crate rawsql;
 
-use rawsql::Loader;
 use postgres::{Connection, SslMode};
+use rawsql::Loader;
 
 struct Person {
     id: i32,
@@ -10,17 +10,18 @@ struct Person {
     data: Option<Vec<u8>>,
 }
 
-
 fn main() {
     let conn = Connection::connect("postgres://postgres:local@localhost", &SslMode::None).unwrap();
 
-    let queries = Loader::get_queries_from("examples/postgre.sql").unwrap().queries;
+    let queries = Loader::get_queries_from("examples/postgre.sql").unwrap();
 
     // Drop table
-    conn.execute(queries.get("drop-table-person").unwrap(), &[]).unwrap();
+    conn.execute(queries.get("drop-table-person").unwrap(), &[])
+        .unwrap();
 
     // Create table
-    conn.execute(queries.get("create-table-person").unwrap(), &[]).unwrap();
+    conn.execute(queries.get("create-table-person").unwrap(), &[])
+        .unwrap();
 
     let me = Person {
         id: 0,

--- a/examples/postgre.rs
+++ b/examples/postgre.rs
@@ -1,7 +1,7 @@
 extern crate postgres;
 extern crate rawsql;
 
-use postgres::{Connection, SslMode};
+use postgres::{Client, NoTls};
 use rawsql::Loader;
 
 struct Person {
@@ -11,7 +11,7 @@ struct Person {
 }
 
 fn main() {
-    let conn = Connection::connect("postgres://postgres:local@localhost", &SslMode::None).unwrap();
+    let mut conn = Client::connect("postgres://postgres:local@localhost", NoTls).unwrap();
 
     let queries = Loader::get_queries_from("examples/postgre.sql").unwrap();
 
@@ -34,8 +34,7 @@ fn main() {
         .unwrap();
 
     // Select
-    let stmt = conn.prepare(queries.get("select-all").unwrap()).unwrap();
-    for row in stmt.query(&[]).unwrap() {
+    for row in conn.query(queries.get("select-all").unwrap(), &[]).unwrap() {
         let person = Person {
             id: row.get(0),
             name: row.get(1),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{Read, Result},
+    ops::Deref,
 };
 
 struct Parser {
@@ -124,12 +125,16 @@ impl Parser {
 }
 
 /// All queries info
-pub struct Loader {
-    /// Queries as key(name) and value(query)
-    pub queries: HashMap<String, String>,
-}
+/// Queries as key(name) and value(query)
+pub struct Loader(pub HashMap<String, String>);
 
-//TODO: use pub struct Loader(pub HashMap<String, String>) + implement deref
+impl Deref for Loader {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl Loader {
     ///Given a string content retrieve all the queries.
@@ -153,7 +158,7 @@ impl Loader {
                 parser = Parser::init()
             }
         }
-        Ok(Loader { queries })
+        Ok(Loader(queries))
     }
 
     ///Given a path of file retrieve all the queries.
@@ -194,21 +199,21 @@ mod tests {
             Err(why) => panic!("{}", why),
         };
 
-        let q_simple = match res.queries.get("simple") {
+        let q_simple = match res.get("simple") {
             Some(r) => r,
             None => panic!("no result on get query"),
         };
 
         assert_eq!(q_simple, "SELECT * FROM table1 u where  u.name = ?;");
 
-        let q_2_lines = match res.queries.get("two-lines") {
+        let q_2_lines = match res.get("two-lines") {
             Some(r) => r,
             None => panic!("no result on get query"),
         };
 
         assert_eq!(q_2_lines, "Insert INTO table2 SELECT * FROM table1;");
 
-        let q_complex = match res.queries.get("complex") {
+        let q_complex = match res.get("complex") {
             Some(r) => r,
             None => panic!("no result on get query"),
         };
@@ -220,7 +225,7 @@ mod tests {
              a.Status = ?;"
         );
 
-        let q_psql = match res.queries.get("psql-insert") {
+        let q_psql = match res.get("psql-insert") {
             Some(r) => r,
             None => panic!("no result on get query"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,19 +94,19 @@ impl Parser {
         let tag = line
             .replace("--", "")
             .replace("name", "")
-            .replace(":", "")
-            .trim_left()
+            .replace(':', "")
+            .trim_start()
             .to_string();
-        self.name = tag.to_string();
+        self.name = tag;
         self.query = "".to_string();
     }
 
     fn build_query(&mut self, line: &str) {
-        let q = line.trim_left();
+        let q = line.trim_start();
         if self.query.is_empty() {
             self.query = q.to_string();
         } else {
-            self.query = self.query.to_string() + " " + &q;
+            self.query = self.query.to_string() + " " + q
         }
     }
 
@@ -115,7 +115,7 @@ impl Parser {
     }
 
     fn is_finishing_query(&mut self, line: &str) -> bool {
-        !self.query.is_empty() && line.ends_with(";")
+        !self.query.is_empty() && line.ends_with(';')
     }
 
     fn is_tagged_name(&mut self, line: &str) -> bool {


### PR DESCRIPTION
With that version, we can parse a string containing SQL queries. 

Doing that, we are now able to load the sql file at compile-time using `include_str!(myfile)` and therefore it makes our binary independent from the sql file at run-time. 

Killing two birds with one stone: the code is now compliant with new rust standards. 